### PR TITLE
bugfix/fixed runtime error

### DIFF
--- a/src/components/Body/Gameboard/GameOver/GameOverModal.jsx
+++ b/src/components/Body/Gameboard/GameOver/GameOverModal.jsx
@@ -29,7 +29,7 @@ export const GameOverModal = ({ setRestart, numFreeTiles, winner, setPlayerTurnA
         <Grid>
             <Dialog
                 open={open}
-                onClose={handleClose}>
+                onClose={() => handleClose(1, setPlayerTurnArr, setOpen, setRestart, setGameScreenshots)}>
                 <DialogTitle id="game-over-alert"
                     sx={{ backgroundColor: theme === DARK_THEME ? BACKGROUND_COLOR_DARK : BACKGROUND_COLOR_LIGHT }}>
                     <Typography variant='h3'


### PR DESCRIPTION
## Summary
#14 Fixed a bug where clicking outside the game-over modal window after the game ended caused a runtime crash.

## Description
Implemented proper handling of click events outside the game-over modal to prevent runtime crashes. The modal now remains stable and responsive even after the game has entered a game-over state.

### Changes Made
- Modified onClose prop of MUI dialog component.
- Ensured the modal remains functional and does not crash when interacted with post-game.

## How was this tested?
- **Manual Testing**: Verified the fix by playing through multiple game sessions, ensuring the modal behaves correctly after the game ends.
