### PR TITLE
Fixed snapshot count issue

### DIFF
--- a/src/components/Body/TurnList/TurnList.jsx
+++ b/src/components/Body/TurnList/TurnList.jsx
@@ -32,7 +32,7 @@ export const TurnList = ({ playerTurnArr, gameScreenshots, theme }) => {
                         </AccordionSummary>
                         <AccordionDetails>
                             <Grid sx={{ borderTop: 2, pt: 2, color: handleColorText(theme) }}>
-                                <Typography variant="p" fontSize={24} p={'4rem'} >{`Snapshot {count}`}</Typography>
+                                <Typography variant="p" fontSize={24} p={'4rem'} >{`Snapshot ${count}`}</Typography>
                             </Grid>
                             <Grid className="css-152lgj-MuiAccordionDetails-root">
                                 <PrevBoard gameScreenshot={gameScreenshots[count - 1]}


### PR DESCRIPTION
# Description
Resolved the issue with snapshot count, ensuring it now displays the correct snapshot number.

# How was this tested?
[X] Manual Testing: Verified that the snapshot number remains consistent with the number of turns.

## Screenshots
### Snapshot turn display (Light mode)
![image](https://github.com/user-attachments/assets/7acc8d8f-351c-43bd-ad99-214d23069e1d)

### Snapshot turn display (Dark mode)
![image](https://github.com/user-attachments/assets/ec7d8a81-cd51-4f23-8b8d-318ea3d9410f)


